### PR TITLE
Add `daily()` to command

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To frequently check all links you can schedule the command:
 protected function schedule(Schedule $schedule)
 {
     ...
-    $schedule->command('link-checker:run')->sundays();
+    $schedule->command('link-checker:run')->sundays()->daily();
 }
 ``` 
 


### PR DESCRIPTION
`$schedule->command('link-checker:run')->sundays()` happily runs all sunday long.
`$schedule->command('link-checker:run')->sundays()->daily()` only once.
![dg6wmurwsaaqncl](https://user-images.githubusercontent.com/7462542/32699169-70507094-c7b1-11e7-8701-06ad1035ad43.jpg)


https://twitter.com/arubacao/status/895819384391913472