### PR TITLE
Allow users to exclude status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ return [
              */
             'subject' => '',
         ],
+
+        /*
+         * If you wish to exclude status codes from the reporters,
+         * you can select the status codes that you wish to
+         * exclude in the array below like: [200, 302]
+         */
+        'exclude_status_codes' => [],
     ],
 ];
 ```

--- a/resources/config/laravel-link-checker.php
+++ b/resources/config/laravel-link-checker.php
@@ -47,6 +47,13 @@ return [
              */
             'subject' => '',
 
-        ]
+        ],
+
+        /*
+         * If you wish to exclude status codes from the reporters,
+         * you can select the status codes that you wish to
+         * exclude in the array below like: [200, 302]
+         */
+        'exclude_status_codes' => [],
     ]
 ];

--- a/src/Reporters/BaseReporter.php
+++ b/src/Reporters/BaseReporter.php
@@ -36,7 +36,9 @@ abstract class BaseReporter implements CrawlObserver
     {
         $statusCode = $response ? $response->getStatusCode() : static::UNRESPONSIVE_HOST;
 
-        $this->urlsGroupedByStatusCode[$statusCode][] = $url;
+        if (!$this->excludeStatusCode($statusCode)) {
+            $this->urlsGroupedByStatusCode[$statusCode][] = $url;
+        }
 
         return $statusCode;
     }
@@ -61,5 +63,17 @@ abstract class BaseReporter implements CrawlObserver
         return collect($this->urlsGroupedByStatusCode)->keys()->filter(function ($statusCode) {
             return !$this->isSuccessOrRedirect($statusCode);
         })->count() > 0;
+    }
+
+    /**
+     * Determine if the statuscode should be excluded'
+     * from the reporter.
+     *
+     * @param int|string $statusCode
+     * @return bool
+     */
+    protected function excludeStatusCode($statusCode): bool
+    {
+        return in_array($statusCode, config('laravel-link-checker.reporters.exclude_status_codes', []));
     }
 }

--- a/src/Reporters/LogBrokenLinks.php
+++ b/src/Reporters/LogBrokenLinks.php
@@ -33,7 +33,7 @@ class LogBrokenLinks extends BaseReporter
     {
         $statusCode = parent::hasBeenCrawled($url, $response);
 
-        if ($this->isSuccessOrRedirect($statusCode)) {
+        if ($this->isSuccessOrRedirect($statusCode) || $this->excludeStatusCode($statusCode)) {
             return;
         }
 

--- a/src/Reporters/LogBrokenLinks.php
+++ b/src/Reporters/LogBrokenLinks.php
@@ -33,7 +33,11 @@ class LogBrokenLinks extends BaseReporter
     {
         $statusCode = parent::hasBeenCrawled($url, $response);
 
-        if ($this->isSuccessOrRedirect($statusCode) || $this->excludeStatusCode($statusCode)) {
+        if ($this->isSuccessOrRedirect($statusCode)) {
+            return;
+        }
+
+        if ($this->excludeStatusCode($statusCode)) {
             return;
         }
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -76,6 +76,16 @@ abstract class IntegrationTest extends Orchestra
     }
 
     /**
+     * Determine if log does not contains the given text after the last mark.
+     *
+     * @param $text
+     */
+    public function assertLogNotContainsTextAfterLastMarker($text)
+    {
+        $this->assertNotContains($text, $this->getLogContentsAfterLastMarker());
+    }
+
+    /**
      * Get the contents of the log after the last marker.
      *
      * @return string

--- a/tests/LogBrokenUrlsTest.php
+++ b/tests/LogBrokenUrlsTest.php
@@ -21,4 +21,21 @@ class LogBrokenUrlsTest extends IntegrationTest
         $this->assertLogContainsTextAfterLastMarker('Crawled 1 url(s) with statuscode 400');
         $this->assertLogContainsTextAfterLastMarker('Crawled 1 url(s) with statuscode 500');
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_report_excluded_status_codes()
+    {
+        $this->placeMarker();
+
+        $this->app['config']->set('laravel-link-checker.reporters.exclude_status_codes', [500]);
+        $this->app[Kernel::class]->call('link-checker:run', ['--url' => $this->appUrl]);
+
+        $this->assertLogContainsTextAfterLastMarker('400 Bad Request - http://localhost:4020/400');
+        $this->assertLogNotContainsTextAfterLastMarker('500 Internal Server Error - http://localhost:4020/500');
+        $this->assertLogContainsTextAfterLastMarker('link checker summary');
+        $this->assertLogContainsTextAfterLastMarker('Crawled 1 url(s) with statuscode 400');
+        $this->assertLogNotContainsTextAfterLastMarker('Crawled 1 url(s) with statuscode 500');
+    }
 }


### PR DESCRIPTION
Users can now exclude specific status codes from being logged and emailed.

As requested at #31 