### PR TITLE
Client options

### DIFF
--- a/resources/config/laravel-link-checker.php
+++ b/resources/config/laravel-link-checker.php
@@ -26,17 +26,29 @@ return [
     'concurrency' => 10,
 
     /*
+     * List of client options to use in Guzzle HTTP.
+     */
+    'client_options' => [
+
+        \GuzzleHttp\RequestOptions::COOKIES => true,
+        \GuzzleHttp\RequestOptions::CONNECT_TIMEOUT => 10,
+        \GuzzleHttp\RequestOptions::TIMEOUT => 10,
+        \GuzzleHttp\RequestOptions::ALLOW_REDIRECTS => false,
+
+    ],
+
+    /*
      * Configuration regarding the used reporters.
      */
     'reporters' => [
 
         'mail' => [
-            
+
             /*
              * The from address to be used by the mail reporter.
              */
             'from_address' => '',
-            
+
             /*
              * The to address to be used by the mail reporter.
              */

--- a/src/CheckLinksCommand.php
+++ b/src/CheckLinksCommand.php
@@ -33,11 +33,30 @@ class CheckLinksCommand extends Command
         Crawler::create()
             ->setCrawlProfile($this->getProfile())
             ->setCrawlObserver($this->getReporter())
+            ->setConcurrency($this->getConcurrency())
             ->startCrawling($this->getUrlToBeCrawled());
 
         $this->info('All done!');
     }
 
+    /**
+     * Returns concurrency. If not found, simply returns a default value like
+     * 10 (default from spatie/crawler).
+     *
+     * @return int
+     */
+    protected function getConcurrency(): int
+    {
+        if ($this->option('concurrency') !== null) {
+            return $this->option('concurrency');
+        }
+
+        if (config('laravel-link-checker.concurrency') != '') {
+            return config('laravel-link-checker.concurrency');
+        }
+
+        return 10;
+    }
     /**
      * Determine the url to be crawled.
      *

--- a/src/CheckLinksCommand.php
+++ b/src/CheckLinksCommand.php
@@ -30,7 +30,7 @@ class CheckLinksCommand extends Command
 
     public function handle()
     {
-        Crawler::create()
+        Crawler::create(config('laravel-link-checker.client_options', []))
             ->setCrawlProfile($this->getProfile())
             ->setCrawlObserver($this->getReporter())
             ->setConcurrency($this->getConcurrency())
@@ -57,6 +57,7 @@ class CheckLinksCommand extends Command
 
         return 10;
     }
+
     /**
      * Determine the url to be crawled.
      *


### PR DESCRIPTION
This little PR implements `client_options` that could change the default behavior of the crawler like `headers`, `auth`, etc. It also implements `setConcurrency` method on command constructor